### PR TITLE
Fix: Improve visual distinction for generic map entity highlights

### DIFF
--- a/components/MapDisplay.tsx
+++ b/components/MapDisplay.tsx
@@ -602,18 +602,18 @@ const MapDisplay: React.FC<MapDisplayProps> = ({
         {isWorldPopulated && (mapViewMode === 'biomes' || mapViewMode === 'regions' || mapViewMode === 'realistic' || mapViewMode === 'elevation') && ( 
             <>
                 {hoveredRegionId && hoveredRegionId !== selectedRegionId && hoveredRegionBorders.length > 0 && (
-                    <path d={bordersToPath(hoveredRegionBorders)} stroke={HOVER_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.1) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
+                    <path d={bordersToPath(hoveredRegionBorders)} stroke={HOVER_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.0) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
                 )}
                 {selectedRegionId && selectedRegionBorders.length > 0 && (
-                    <path d={bordersToPath(selectedRegionBorders)} stroke={SELECTED_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.2) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
+                    <path d={bordersToPath(selectedRegionBorders)} stroke={SELECTED_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.5) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
                 )}
                 {hoveredBiomeId && hoveredBiomeId !== selectedBiomeId && hoveredBiomeBorders.length > 0 &&
                     (!selectedRegionId || mapBiomes.find(b => b.id === hoveredBiomeId)?.regionId !== selectedRegionId) && (
-                    <path d={bordersToPath(hoveredBiomeBorders)} stroke={HOVER_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.1) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
+                    <path d={bordersToPath(hoveredBiomeBorders)} stroke={HOVER_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.0) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
                 )}
                 {selectedBiomeId && selectedBiomeBorders.length > 0 &&
                     (!selectedRegionId || mapBiomes.find(b => b.id === selectedBiomeId)?.regionId !== selectedRegionId) && (
-                    <path d={bordersToPath(selectedBiomeBorders)} stroke={SELECTED_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.2) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
+                    <path d={bordersToPath(selectedBiomeBorders)} stroke={SELECTED_BORDER_COLOR} strokeWidth={(GENERIC_HIGHLIGHT_BORDER_WIDTH * 1.5) / zoomLevel} fill="none" vectorEffect="non-scaling-stroke"/>
                 )}
             </>
         )}


### PR DESCRIPTION
Previously, the stroke width difference between hovered and selected generic map entities (biomes, regions) was minimal (0.25 logical units), and colors were similar shades of yellow. This could lead to your confusion in differentiating between these states.

This change modifies the stroke width multipliers in MapDisplay.tsx:
- Hovered generic entities now use a 1.0x multiplier of GENERIC_HIGHLIGHT_BORDER_WIDTH.
- Selected generic entities now use a 1.5x multiplier of GENERIC_HIGHLIGHT_BORDER_WIDTH.

This results in a more significant difference in border thickness (e.g., 2.5 vs 3.75 logical units), enhancing the clarity of these visual states for you. Political entity border styles remain unchanged as their distinction mechanisms (color, outlines) were already considered sufficient.